### PR TITLE
bash has a regex operator

### DIFF
--- a/k8s-cluster-export
+++ b/k8s-cluster-export
@@ -220,7 +220,7 @@ function export_resource {
     RESULT=$TARGET_FOLDER'/'$TYPE'_'$i'.yaml'
     status_output "export $i config" "step"
     # skip default token secret in export
-    if [ $i != default-token-86222 ] && [ ${TYPE} != "secrets" ]; then
+    if [[ ! $i =~ ^default-token-[0-9a-z]{5} ]] || [ ${TYPE} != "secrets" ]; then
       # export resource and adjust the output
       kubectl get $TYPE $i -o yaml -n ${NAMESPACE} > $RAW
       cp $RAW $RESULT


### PR DESCRIPTION
I think this is what was intended.  I did some digging and TIL there is a regex operator in bash!

It looks like the original version was actually skipping export of all secrets, but from the comment I gathered that you intended to skip only the default token (which K8s automatically places into every namespace for you, so is clearly not needed in any export.)